### PR TITLE
Work universally (server-side, in builder, in browser)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,16 +5,15 @@ let translate;
 fetch = function(){ return ''; };
 
 translate = function(load) {
-    load.metadata.format = 'amd';
-
-    return System.import(this.builder ? './sass-inject-build' : './sass-inject', { name: __moduleName })
-      .then(function(inject){
-        return inject.default(load);
-      })
-      .then(function(css){
-        const output = 'def' + 'ine(function() {\nreturn "' + css.trim().replace('\n', '') + '";\n});';
-        return (!!css) ? output : '';
-      })
+	return System.import(typeof window !== 'undefined' ? './sass-inject' : './sass-inject-build', { name: __moduleName })
+	  .then(function(inject){
+		return inject.default(load);
+	  })
+	  .then(function(css){
+		load.metadata.format = 'amd';
+		const output = 'def' + 'ine(function() {\nreturn "' + css.trim().replace('\n', '') + '";\n});';
+		return (!!css) ? output : '';
+	  })
 };
 
 export { fetch, translate };


### PR DESCRIPTION
These changes preserve how it worked in the builder and in the browser, but adds support for using it server-side for universal apps. I was getting 'window is not defined' errors previously.
