### PR TITLE
fix: convert backticks and add braces to arrow functions

### DIFF
--- a/src/resolve-path.js
+++ b/src/resolve-path.js
@@ -12,8 +12,10 @@ const resolvePath = (request) => {
             if (!current.match(/\.s(c|a)ss/))
                 current += '.scss';
             System.normalize(current)
-                .then(file => resolve(file.replace(/\.js$|\.ts$/, '')))
-                .catch(e => reject(e));
+                .then(file => {
+                  resolve(file.replace(/\.js$|\.ts$/, ''));
+                })
+                .catch(e => { reject(e); });
         } else {
             const prevBase = path.dirname(previous) + '/';
             const base = (previous === 'stdin') ? request.options.urlBase : paths[previous] || prevBase;
@@ -22,7 +24,7 @@ const resolvePath = (request) => {
             if (!resolved.match(/\.s(c|a)ss/))
                 resolved += '.scss';
 
-            resolve(`${resolved}`);
+            resolve(resolved);
         }
     });
 };

--- a/src/sass-inject-build.js
+++ b/src/sass-inject-build.js
@@ -29,7 +29,7 @@ const loadFile = function(file) {
 
 const fromFileURL = url => {
     const address = decodeURIComponent(url.replace(/^file:(\/+)?/i, ''));
-    return !isWin ? `/${address}` : address.replace(/\//g, '\\');
+    return !isWin ? '/' + address : address.replace(/\//g, '\\');
 };
 
 // intercept file loading requests (@import directive) from libsass
@@ -48,14 +48,16 @@ sass.importer(function(request, done) {
             readPartialPath = fromFileURL(partialUrl);
             return loadFile(readPartialPath);
         })
-        .then(data => content = data)
-        .catch(() => loadFile(readImportPath))
-        .then(data => content = data)
-        .then(() => done({
+        .then(data => { content = data; })
+        .catch(() => { loadFile(readImportPath); })
+        .then(data => { content = data; })
+        .then(() => {
+          done({
             content,
             path: resolved,
-        }))
-        .catch(() => done());
+          });
+        })
+        .catch(() => { done(); });
 });
 
 export default function(loadObject) {
@@ -63,7 +65,7 @@ export default function(loadObject) {
 
         return new Promise((resolve, reject) => {
 
-            const urlBase = `${path.dirname(load.address)}/`;
+            const urlBase = path.dirname(load.address) + '/';
 
             let options = {};
 


### PR DESCRIPTION
Fixes #11 

Not as pretty, but works in my gulp tasks now.
